### PR TITLE
Makefile: Fix .PHONY declaration syntax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-.PHONY = all clean
-
 all: dyn/target/debug/dyn ent/target/x86_64-unknown-linux-musl/debug/ent noe/target/debug/noe
 
 clean:
@@ -21,3 +19,5 @@ noe/target/debug/noe:
 	cargo build --manifest-path=noe/Cargo.toml -Z extra-link-arg
 	file $@
 	$@
+
+.PHONY: all clean


### PR DESCRIPTION
.PHONY uses the syntax of a target (with ':'), not a variable (with '=').

Move .PHONY to the end, so that it doesn't look like a default target.

To test this, `touch clean` and then try `make clean`. Without this
change, make will say `make: 'clean' is up to date.`. With this change,
make treats the `clean` target as phony.